### PR TITLE
Allow settings overrides for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ First, add a directory within your startup folder named `events`. Within this di
 each event you'd like to deploy.
 
 `event-name.json` will have configuration, specifically the `depcfg` configuration for source buckets,
-metadata buckets, and buckets which may be referenced by the event. An easy way to get these settings is
-to manually configure an event, then get the definition from `http://localhost:8096/api/v1/functions`
+metadata buckets, and buckets which may be referenced by the event. The `settings` attribute can also be
+used to override any settings, defaults apply for any excluded settings. An easy way to get these
+settings is to manually configure an event and then get the definition from `http://localhost:8096/api/v1/functions`
 (use HTTP Basic Authentication).
 
 ```json
@@ -168,6 +169,9 @@ to manually configure an event, then get the definition from `http://localhost:8
     "curl": [],
     "metadata_bucket": "default",
     "source_bucket": "sample"
+  },
+  "settings": {
+    "worker_count": 3
   }
 }
 ```
@@ -191,6 +195,10 @@ This means that all documents in the source bucket should be processed by the ev
 including any documents created from models. However, the `/nodestatus/initialized` file will be
 created before all documents are processed, as events are asynchronous in nature.
 
+Also, note that by default logging will be set to the DEBUG level and each event will use only 1
+worker. This is because CouchbaseFakeIt is intended for local machine development or CI testing.
+These settings can be overridden in the JSON file in the `settings` attribute.
+
 ### Example
 
 An example image configuration can be found [here](example/).
@@ -201,7 +209,7 @@ To run the example locally:
 2. `git clone https://github.com/brantburnett/couchbasefakeit.git`
 3. `cd couchbasefakeit/example`
 4. `docker-compose up -d`
-5. The server will be accessible at http://localhost:8091 after 15-30 seconds. The username is "Administrator", password is "mypassword".
+5. The server will be accessible at http://localhost:8091 after 15-30 seconds. The username is "Administrator", password is "password".
 
 To shut down and cleanup:
 

--- a/example/events/my-event.json
+++ b/example/events/my-event.json
@@ -10,5 +10,8 @@
     "curl": [],
     "metadata_bucket": "default",
     "source_bucket": "sample"
+  },
+  "settings": {
+    "worker_count": 3
   }
 }

--- a/scripts/create-events.sh
+++ b/scripts/create-events.sh
@@ -11,6 +11,7 @@ if [ -e "/startup/events/" ]; then
     cat event_template.json |
       jq -c ".appname = \"$eventName\"" |
       jq --argfile source $filename -c ".depcfg = \$source.depcfg" |
+      jq --argfile source $filename -c ".settings = .settings * \$source.settings" |
       jq --rawfile source /startup/events/$eventName.js -c ".appcode = \$source" |
       curl -Ss -X POST -u "$CB_USERNAME:$CB_PASSWORD" -H "Content-Type: application/json" \
         -d @- http://127.0.0.1:8096/api/v1/functions/$eventName \

--- a/scripts/event_template.json
+++ b/scripts/event_template.json
@@ -9,10 +9,10 @@
         "deployment_status": true,
         "description": "",
         "execution_timeout": 60,
-        "log_level": "INFO",
+        "log_level": "DEBUG",
         "n1ql_consistency": "none",
         "processing_status": true,
         "user_prefix": "eventing",
-        "worker_count": 3
+        "worker_count": 1
     }
 }


### PR DESCRIPTION
Motivation
----------
Allow settings to be overridden, but set better defaults for local dev
and testing.

Modifications
-------------
Make default worker count 1 instead of 3, and set debug instead of info
logging for events.

Override any settings in to event JSON file by merging them on top of
the default settings from the template.