### PR TITLE
Deprecate Couchbase Server 5.0 and 5.1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,8 +20,6 @@ jobs:
     strategy:
       matrix:
         couchbase-version:
-          - enterprise-5.0.1
-          - enterprise-5.1.1
           - enterprise-5.5.2
           - enterprise-6.0.3
           - enterprise-6.5.1
@@ -42,7 +40,6 @@ jobs:
             docker build . --file Dockerfile --build-arg COUCHBASE_TAG=${{ matrix.couchbase-version }}
           fi
 
-  # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     # Ensure test job passes before pushing image.
@@ -54,8 +51,6 @@ jobs:
     strategy:
       matrix:
         couchbase-version:
-          - enterprise-5.0.1
-          - enterprise-5.1.1
           - enterprise-5.5.2
           - enterprise-6.0.3
           - enterprise-6.5.1


### PR DESCRIPTION
They are very out of date and have compatibility issues with current scripts.