### PR TITLE
Add 7.6.3

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
           - enterprise-7.1.6
           - community-7.2.2
           - enterprise-7.2.3
-          - community-7.6.3
+          - community-7.6.2
           - enterprise-7.6.3
 
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,14 +22,18 @@ jobs:
           - enterprise-7.1.6
           - community-7.2.2
           - enterprise-7.2.3
+          - community-7.6.3
+          - enterprise-7.6.3
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: ${{ github.ref == 'ref/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           username: btburnett3
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
           context: .
           build-args: "COUCHBASE_TAG=${{ matrix.couchbase-version }}"
           platforms: linux/amd64
-          push: ${{ github.ref == 'ref/heads/main' }}
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: "btburnett3/couchbasefakeit:${{ matrix.couchbase-version }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        if: ${{ github.ref == 'ref/heads/main' }}
         with:
           username: btburnett3
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -46,7 +47,7 @@ jobs:
           context: .
           build-args: "COUCHBASE_TAG=${{ matrix.couchbase-version }}"
           platforms: linux/amd64
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.ref == 'ref/heads/main' }}
           tags: "btburnett3/couchbasefakeit:${{ matrix.couchbase-version }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
# Motivations
Latest couchbase server version

# Modifications
- Add 7.6.3 to the list of couchbase versions to build docker images based on